### PR TITLE
Experimantal workaround to force the game to evaluate armor addon slots.

### DIFF
--- a/package/Data/scripts/Source/DDNF_MainQuest_Player.psc
+++ b/package/Data/scripts/Source/DDNF_MainQuest_Player.psc
@@ -5,7 +5,7 @@ Scriptname DDNF_MainQuest_Player extends ReferenceAlias
 
 Formlist Property EmptyFormlist Auto
 
-String Property Version = "0.1 beta 5" AutoReadOnly
+String Property Version = "0.1 beta 6 EXPERIMENTAL" AutoReadOnly
 String _lastVersion
 
 

--- a/package/Data/scripts/Source/DDNF_NpcTracker_NPC.psc
+++ b/package/Data/scripts/Source/DDNF_NpcTracker_NPC.psc
@@ -418,6 +418,7 @@ Event OnUpdate()
     EndIf
     If (EquipAllDevices(npc, _renderedDevices) > 0) ; even do this if current state has changed during UnequipAllDevices!
         Utility.Wait(0.1) ; give the game time to fully register the equips
+        npc.UpdateWeight(0) ; workaround to force the game to correctly evaluate armor addon slots
     EndIf
     String currentState = GetState()
     If (_ignoreNotEquippedInNextFixup)


### PR DESCRIPTION
This should fix clipping of hands in elbowbinders, and might also fix some other issues.