### PR TITLE
Version 0.1 RC 2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,3 +37,4 @@ Version 0.1 RC 1
 Version 0.1 RC 2
 - Optimization: Detect if an added/removed device does not change the existing animations (e.g. when gagging bound NPCs) and skip refreshing animations in that case.
 - Optimization: Refactor detection of keywords on devices, will hopefully reduce the amount of keyword checks for NPCs wearing many devices.
+- Fix: Prevent NPCs with bondage mittens from using shields.

--- a/changelog.txt
+++ b/changelog.txt
@@ -33,3 +33,7 @@ Version 0.1 RC 1
 - When scanning devices, check for each device if it has an enchantment; if not, assume it has no special functionality (e.g. heavy bondage, different animations).
 - When unequipping and reequipping devices, skip devices that have no enchantment (they have no effect that needs to be restarted).
 - Improve handling of weapons for bound followers: They should no longer try to draw weapons, and they should no longer run with one or both arms sticking out.
+
+Version 0.1 RC 2
+- Optimization: Detect if an added/removed device does not change the existing animations (e.g. when gagging bound NPCs) and skip refreshing animations in that case.
+- Optimization: Refactor detection of keywords on devices, will hopefully reduce the amount of keyword checks for NPCs wearing many devices.

--- a/package/Data/scripts/Source/DDNF_MainQuest_Player.psc
+++ b/package/Data/scripts/Source/DDNF_MainQuest_Player.psc
@@ -5,7 +5,7 @@ Scriptname DDNF_MainQuest_Player extends ReferenceAlias
 
 Formlist Property EmptyFormlist Auto
 
-String Property Version = "0.1 RC 1" AutoReadOnly
+String Property Version = "0.1 RC 2" AutoReadOnly
 String _lastVersion
 
 


### PR DESCRIPTION
- Optimization: Detect if an added/removed device does not change the existing animations (e.g. when gagging bound NPCs) and skip refreshing animations in that case.
- Optimization: Refactor detection of keywords on devices, will hopefully reduce the amount of keyword checks for NPCs wearing many devices.
- Fix: Prevent NPCs with bondage mittens from using shields.
